### PR TITLE
Generate and export signed transactions in the fuzzer too

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,10 @@ dependencies {
   implementation 'com.jayway.jsonpath:json-path:2.4.0'
   implementation 'org.apache.commons:commons-math3:3.6.1'
 
+  testImplementation 'junit:junit:4.13'
+  testImplementation 'org.assertj:assertj-core:3.16.1'
+  testImplementation 'org.mockito:mockito-core:3.3.3'
+
 
   annotationProcessor 'com.google.dagger:dagger-compiler:2.28.1'
   annotationProcessor 'org.immutables:value:2.8.8'

--- a/src/main/java/tech/pegasys/net/api/service/transaction/TransactionSigner.java
+++ b/src/main/java/tech/pegasys/net/api/service/transaction/TransactionSigner.java
@@ -53,7 +53,7 @@ public class TransactionSigner {
 
   public static byte[] sign(final RawTransaction rawTransaction, final Credentials credentials) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    System.out.println(gson.toJson(rawTransaction));
+    // System.out.println(gson.toJson(rawTransaction));
     return TransactionEncoder.signMessage(rawTransaction, credentials);
   }
 }

--- a/src/main/java/tech/pegasys/net/api/service/transaction/TransactionSigner.java
+++ b/src/main/java/tech/pegasys/net/api/service/transaction/TransactionSigner.java
@@ -2,8 +2,6 @@ package tech.pegasys.net.api.service.transaction;
 
 import java.math.BigInteger;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.web3j.crypto.Credentials;
 import org.web3j.crypto.RawTransaction;
 import org.web3j.crypto.TransactionEncoder;
@@ -52,8 +50,6 @@ public class TransactionSigner {
   }
 
   public static byte[] sign(final RawTransaction rawTransaction, final Credentials credentials) {
-    Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    // System.out.println(gson.toJson(rawTransaction));
     return TransactionEncoder.signMessage(rawTransaction, credentials);
   }
 }

--- a/src/main/java/tech/pegasys/net/cli/Options.java
+++ b/src/main/java/tech/pegasys/net/cli/Options.java
@@ -136,6 +136,13 @@ public class Options {
       description = "Location of genesis file. (default: ${DEFAULT-VALUE})")
   private String genesisFile = null;
 
+  @Option(
+      names = {"--tx-export-file"},
+      paramLabel = "<path>",
+      arity = "1",
+      description = "Location of transaction export file. (default: ${DEFAULT-VALUE})")
+  private String transactionExportFile = null;
+
   public static Options getInstance() {
     return instance;
   }
@@ -176,6 +183,7 @@ public class Options {
         .natsURL(natsURL)
         .natsAsyncConnection(natsAsyncConnection)
         .natsFuzzerTopicTransactions(natsFuzzerTopicTransactions)
+        .transactionExportFile(transactionExportFile)
         .build();
   }
 }

--- a/src/main/java/tech/pegasys/net/config/ChainFillerConfiguration.java
+++ b/src/main/java/tech/pegasys/net/config/ChainFillerConfiguration.java
@@ -35,4 +35,6 @@ public interface ChainFillerConfiguration {
   boolean natsAsyncConnection();
 
   String natsFuzzerTopicTransactions();
+
+  String transactionExportFile();
 }

--- a/src/main/java/tech/pegasys/net/config/FillerMode.java
+++ b/src/main/java/tech/pegasys/net/config/FillerMode.java
@@ -5,7 +5,8 @@ public enum FillerMode {
   SCHEDULER,
   CONTINUOUS,
   EXTERNAL_FUZZER_NATS,
-  BATCH_RPC;
+  BATCH_RPC,
+  TX_EXPORT;
 
   public static FillerMode fromString(final String str) {
     for (final FillerMode mode : FillerMode.values()) {

--- a/src/main/java/tech/pegasys/net/core/ChainFillerService.java
+++ b/src/main/java/tech/pegasys/net/core/ChainFillerService.java
@@ -24,6 +24,7 @@ import tech.pegasys.net.api.service.transaction.LegacyTransactionCreator;
 import tech.pegasys.net.config.ChainFillerConfiguration;
 import tech.pegasys.net.core.account.AccountProcessorService;
 import tech.pegasys.net.core.batch.BatchRpcFillerService;
+import tech.pegasys.net.core.tx.export.TxExportService;
 import tech.pegasys.net.fuzzer.NatsFuzzer;
 
 public class ChainFillerService implements ChainFiller {
@@ -90,6 +91,9 @@ public class ChainFillerService implements ChainFiller {
           final BatchRpcFillerService batchRpcFillerService =
               new BatchRpcFillerService(this, configuration, accounts);
           batchRpcFillerService.start();
+          break;
+        case TX_EXPORT:
+          new TxExportService(this, configuration, accounts).start();
           break;
         case ONESHOT:
         default:

--- a/src/main/java/tech/pegasys/net/core/tx/export/TxExportService.java
+++ b/src/main/java/tech/pegasys/net/core/tx/export/TxExportService.java
@@ -107,7 +107,6 @@ public class TxExportService {
   private static byte[] generateLegacyTransaction(
       final ChainFiller chainFiller, final ActionableAccount account) {
     try {
-      // Logger.debug("generating legacy transaction");
       final LegacyTransaction legacyTransaction =
           chainFiller
               .legacyTransactionCreator()
@@ -124,8 +123,6 @@ public class TxExportService {
   private static byte[] generateEIP1559Transaction(
       final ChainFiller chainFiller, final ActionableAccount account) {
     try {
-      // Logger.debug("generating eip1559 transaction");
-
       final EIP1559Transaction eip1559Transaction =
           chainFiller
               .eip1559TransactionCreator()

--- a/src/main/java/tech/pegasys/net/core/tx/export/TxExportService.java
+++ b/src/main/java/tech/pegasys/net/core/tx/export/TxExportService.java
@@ -1,0 +1,140 @@
+package tech.pegasys.net.core.tx.export;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.tinylog.Logger;
+import org.web3j.utils.Numeric;
+import tech.pegasys.net.api.model.ActionableAccount;
+import tech.pegasys.net.api.model.EIP1559Transaction;
+import tech.pegasys.net.api.model.LegacyTransaction;
+import tech.pegasys.net.api.service.ChainFiller;
+import tech.pegasys.net.api.service.transaction.TransactionSigner;
+import tech.pegasys.net.config.ChainFillerConfiguration;
+
+public class TxExportService {
+
+  private final ChainFiller chainFiller;
+  private final ChainFillerConfiguration configuration;
+  private final List<ActionableAccount> accounts;
+  private final Path outputPath;
+
+  public TxExportService(
+      final ChainFiller chainFiller,
+      final ChainFillerConfiguration configuration,
+      final List<ActionableAccount> accounts) {
+    this.chainFiller = chainFiller;
+    this.configuration = configuration;
+    this.accounts = accounts;
+    this.outputPath = Paths.get(configuration.transactionExportFile());
+    try {
+      Files.createFile(outputPath);
+    } catch (final FileAlreadyExistsException e) {
+      Logger.warn("export file exists and will be deleted");
+      try {
+        Files.delete(outputPath);
+        Files.createFile(outputPath);
+      } catch (final IOException ioe) {
+        Logger.error(e, "cannot create export file");
+        throw new RuntimeException(e);
+      }
+    } catch (final IOException e) {
+      Logger.error(e, "cannot create export file");
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void start() {
+    try {
+      final ExecutorService executorService =
+          Executors.newFixedThreadPool(configuration.numThreads());
+      final int eip1559Txs =
+          (int) Math.ceil(configuration.numTransactions() * configuration.eip1559TxWeight());
+      final int legacyTxs = configuration.numTransactions() - eip1559Txs;
+      accounts.forEach(
+          actionableAccount -> {
+            executorService.submit(
+                () ->
+                    IntStream.range(0, legacyTxs)
+                        .forEach(
+                            __ -> {
+                              appendTx(generateLegacyTransaction(chainFiller, actionableAccount));
+                              chainFiller.reporter().incLegacyTransactions();
+                            }));
+            executorService.submit(
+                () ->
+                    IntStream.range(0, eip1559Txs)
+                        .forEach(
+                            __ -> {
+                              appendTx(generateEIP1559Transaction(chainFiller, actionableAccount));
+                              chainFiller.reporter().incEIP1559Transactions();
+                            }));
+          });
+
+      executorService.shutdown();
+      executorService.awaitTermination(1, TimeUnit.DAYS);
+      Logger.debug("completed export: {}", chainFiller.reporter().report());
+    } catch (final Exception e) {
+      Logger.error(e, "error occurred while processing transactions");
+    }
+  }
+
+  private void appendTx(final byte[] tx) {
+    if (tx == null) {
+      return;
+    }
+    try {
+      Files.write(
+          outputPath,
+          Numeric.toHexString(tx).concat(System.lineSeparator()).getBytes(StandardCharsets.UTF_8),
+          StandardOpenOption.APPEND);
+    } catch (final IOException e) {
+      Logger.error(e, "cannot append transaction to export file");
+    }
+  }
+
+  private static byte[] generateLegacyTransaction(
+      final ChainFiller chainFiller, final ActionableAccount account) {
+    try {
+      // Logger.debug("generating legacy transaction");
+      final LegacyTransaction legacyTransaction =
+          chainFiller
+              .legacyTransactionCreator()
+              .create(
+                  BigInteger.valueOf(account.getNonce().getAndIncrement()), account.getGasPrice());
+      return TransactionSigner.sign(legacyTransaction, account.getCredentials());
+    } catch (final Exception e) {
+      Logger.error(e, "error sending legacy transaction");
+      chainFiller.reporter().incLegacyTransactionsError();
+      return null;
+    }
+  }
+
+  private static byte[] generateEIP1559Transaction(
+      final ChainFiller chainFiller, final ActionableAccount account) {
+    try {
+      // Logger.debug("generating eip1559 transaction");
+
+      final EIP1559Transaction eip1559Transaction =
+          chainFiller
+              .eip1559TransactionCreator()
+              .create(BigInteger.valueOf(account.getNonce().getAndIncrement()));
+      return TransactionSigner.sign(eip1559Transaction, account.getCredentials());
+    } catch (final Exception e) {
+      Logger.error(e, "error sending eip1559 transaction");
+      chainFiller.reporter().incEIP1559TransactionsError();
+      return null;
+    }
+  }
+}

--- a/src/test/java/tech/pegasys/net/core/account/AccountProcessorServiceTest.java
+++ b/src/test/java/tech/pegasys/net/core/account/AccountProcessorServiceTest.java
@@ -1,0 +1,11 @@
+package tech.pegasys.net.core.account;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AccountProcessorServiceTest {
+  @Test
+  public void nominalCase() {}
+}

--- a/src/test/java/tech/pegasys/net/core/tx/export/TxExportServiceTest.java
+++ b/src/test/java/tech/pegasys/net/core/tx/export/TxExportServiceTest.java
@@ -1,0 +1,11 @@
+package tech.pegasys.net.core.tx.export;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TxExportServiceTest {
+  @Test
+  public void nominalCase() {}
+}


### PR DESCRIPTION
## Description
We need to be able to pre-generated signed transactions and write those to a file with the RLP encoded hexadecimal string.
This PR adds the possibility to export a configured number of transactions with a ratio of EIP-1559 transactions.

## Sample command
```bash
./build/install/chain-filler/bin/chain-filler \
--account-private-keys=0x8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63 \
--filler-mode=tx_export \
--num-transactions=5 \
--eip-1559-tx-weight=0.4
--num-threads=8
--tx-export-file=/tmp/tx.export
```
## Sample output file
```
0xf867018082520894f8be4ebda7f62d79a665294ec1263bfdb59aabf288253145ccfe0c0000801ca0ab969373bf4582c32a08d717d0dca2e50964196bac8c969840249ce7a91cf1e9a01c291ee4dfad6df5198fa6d8d2140119adb8d95d7f78e3eb1466ead9f214be35
0xf871808082520894f8be4ebda7f62d79a665294ec1263bfdb59aabf288200ec4c2d727000080843b9aca0084773593ff1ca02609373b43c2307c9ef45e879e53ff984c05e2e41b83c161c357e9e79c50e8c6a05faeaeb9db8f94d71a40f3720a1ce090fce47a84edf6d5f319b0981ee851f3b3
0xf871038082520894f8be4ebda7f62d79a665294ec1263bfdb59aabf28811c37937e080000080843b9aca0084773593ff1ba0cac13f02bcb4433fe5885ba1a9f8c8a112c26960f599a522988d1f47165d1d85a03588bdf34e8f739d95c2f60b9cd7a1a8e2d941b584c85b2fecbd8dad1b52833f
0xf867028082520894f8be4ebda7f62d79a665294ec1263bfdb59aabf28827b0c2d8d99e0000801ba06ae46b620417ce31f4a2b456edc7d1162e7714590e3c83cf2b392a77825cf921a01ddd56bc5bb918a09e15c8335eeaab331373c8982f087100132d7479dfe9044e
0xf867048082520894f8be4ebda7f62d79a665294ec1263bfdb59aabf2884563918244f40000801ca0747e1de1bfb3caa748809f78e348b162cea61827d3e2269044487d3d8b9ee4d0a07e280806ef5cc06dff5fe98bfae22af4876cb4c2242a4af4a6d691ea2922e544
```

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>