### PR TITLE
Update 1559 implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
   // Use jcenter for resolving dependencies.
   // You can declare any Maven/Ivy/file repository here.
   jcenter()
+  mavenLocal()
+  mavenCentral()
 }
 
 apply plugin: 'com.diffplug.gradle.spotless'
@@ -48,29 +50,29 @@ spotless {
 }
 
 dependencies {
-  implementation 'com.google.guava:guava:29.0-jre'
-  implementation 'info.picocli:picocli:4.3.2'
-  implementation 'com.google.dagger:dagger:2.28.1'
-  implementation 'org.immutables:value-annotations:2.8.8'
-  implementation 'org.web3j:core:5.0.0'
-  implementation 'org.json:json:20200518'
-  implementation 'org.apache.logging.log4j:log4j-core:2.13.3'
-  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.13.3'
-  implementation 'org.tinylog:tinylog-api:2.1.2'
-  implementation 'org.tinylog:tinylog-impl:2.1.2'
-  implementation 'io.reactivex.rxjava2:rxjava:2.2.19'
-  implementation 'com.google.code.gson:gson:2.8.6'
-  implementation 'io.nats:jnats:2.6.8'
-  implementation 'com.squareup.okhttp3:okhttp:4.7.2'
-  implementation 'com.jayway.jsonpath:json-path:2.4.0'
+  implementation 'com.google.guava:guava:31.1-jre'
+  implementation 'info.picocli:picocli:4.6.3'
+  implementation 'com.google.dagger:dagger:2.42'
+  implementation 'org.immutables:value-annotations:2.9.0'
+  implementation 'org.web3j:core:4.8.5'
+  implementation 'org.json:json:20220320'
+  implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
+  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
+  implementation 'org.tinylog:tinylog-api:2.4.1'
+  implementation 'org.tinylog:tinylog-impl:2.4.1'
+  implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
+  implementation 'com.google.code.gson:gson:2.9.0'
+  implementation 'io.nats:jnats:2.15.3'
+  implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+  implementation 'com.jayway.jsonpath:json-path:2.7.0'
   implementation 'org.apache.commons:commons-math3:3.6.1'
 
-  testImplementation 'junit:junit:4.13'
-  testImplementation 'org.assertj:assertj-core:3.16.1'
-  testImplementation 'org.mockito:mockito-core:3.3.3'
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.assertj:assertj-core:3.23.1'
+  testImplementation 'org.mockito:mockito-core:4.6.1'
 
 
-  annotationProcessor 'com.google.dagger:dagger-compiler:2.28.1'
+  annotationProcessor 'com.google.dagger:dagger-compiler:2.42'
   annotationProcessor 'org.immutables:value:2.8.8'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/tech/pegasys/net/api/model/ActionableAccount.java
+++ b/src/main/java/tech/pegasys/net/api/model/ActionableAccount.java
@@ -40,7 +40,7 @@ public class ActionableAccount {
                   .send()
                   .getTransactionCount()
                   .longValue());
-      //this.gasPrice = web3.ethGasPrice().send().getGasPrice();
+      // this.gasPrice = web3.ethGasPrice().send().getGasPrice();
       this.gasPrice = BigInteger.valueOf(1500000000);
     } catch (Exception e) {
       Logger.error(e, "error setting account parameters (nonce, gasPrice)");
@@ -66,13 +66,13 @@ public class ActionableAccount {
     }
   }
 
-  public AtomicLong getNonce() throws Exception{
+  public AtomicLong getNonce() throws Exception {
     return updated().nonce;
     /*return new AtomicLong(web3.ethGetTransactionCount(
-            credentials.getAddress(), DefaultBlockParameterName.LATEST)
-            .send()
-            .getTransactionCount()
-            .longValue());*/
+    credentials.getAddress(), DefaultBlockParameterName.LATEST)
+    .send()
+    .getTransactionCount()
+    .longValue());*/
   }
 
   public BigInteger getGasPrice() {
@@ -90,5 +90,4 @@ public class ActionableAccount {
   public RpcClientService getRpcClient() {
     return rpcClient;
   }
-
 }

--- a/src/main/java/tech/pegasys/net/api/model/EIP1559Transaction.java
+++ b/src/main/java/tech/pegasys/net/api/model/EIP1559Transaction.java
@@ -6,6 +6,9 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class EIP1559Transaction extends Transaction {
+
+  public abstract long chainId();
+
   public abstract BigInteger gasPremium();
 
   public abstract BigInteger feeCap();

--- a/src/main/java/tech/pegasys/net/api/service/transaction/EIP1559TransactionCreator.java
+++ b/src/main/java/tech/pegasys/net/api/service/transaction/EIP1559TransactionCreator.java
@@ -2,12 +2,16 @@ package tech.pegasys.net.api.service.transaction;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Random;
 
 import org.web3j.utils.Convert;
 import tech.pegasys.net.api.model.EIP1559Transaction;
 import tech.pegasys.net.api.model.payload.TransactionPayload;
 
 public interface EIP1559TransactionCreator {
+
+  Random random = new Random();
 
   EIP1559Transaction create(TransactionPayload transactionPayload);
 
@@ -16,7 +20,26 @@ public interface EIP1559TransactionCreator {
   default EIP1559Transaction create(BigInteger nonce) {
     return create(
         nonce,
-        Convert.Unit.GWEI.getWeiFactor().multiply(BigDecimal.ONE).toBigInteger(),
-        new BigInteger("50000000000", 10));
+        Convert.Unit.GWEI
+            .getWeiFactor()
+            .multiply(getRandomNumberUsingNextIntForTip(new BigInteger("200", 10)))
+            .toBigInteger(),
+        getRandomNumberUsingNextInt(new BigInteger("400000000000", 10)));
+  }
+
+  static BigInteger getRandomNumberUsingNextInt(BigInteger max) {
+    return new BigInteger(max.bitLength(), new SecureRandom())
+        .mod(max)
+        .add(new BigInteger("1000000000000000", 10));
+  }
+
+  static BigDecimal getRandomNumberUsingNextIntForTip(BigInteger max) {
+    return new BigDecimal(
+        new BigInteger(max.bitLength(), new SecureRandom()).mod(max).add(new BigInteger("1", 10)));
+  }
+
+  public static void main(final String[] args) {
+    System.out.println(new BigInteger("50000000000", 10));
+    System.out.println(getRandomNumberUsingNextInt(new BigInteger("50000000000", 10)));
   }
 }

--- a/src/main/java/tech/pegasys/net/api/service/transaction/TransactionSigner.java
+++ b/src/main/java/tech/pegasys/net/api/service/transaction/TransactionSigner.java
@@ -40,6 +40,7 @@ public class TransactionSigner {
       final EIP1559Transaction eip1559Transaction, final Credentials credentials) {
     return sign(
         RawTransaction.createEtherTransaction(
+            eip1559Transaction.chainId(),
             eip1559Transaction.nonce(),
             DEFAULT_GAS_LIMIT,
             eip1559Transaction.recipientAddress(),

--- a/src/main/java/tech/pegasys/net/cli/Options.java
+++ b/src/main/java/tech/pegasys/net/cli/Options.java
@@ -29,6 +29,13 @@ public class Options {
   private List<String> rpcEndpoints = Arrays.asList("http://127.0.0.1:8545");
 
   @Option(
+      names = {"--chain-id"},
+      paramLabel = "<chainId>",
+      description = "Chain ID. ",
+      arity = "1")
+  private long chainId;
+
+  @Option(
       names = {"--account-private-keys"},
       paramLabel = "<privateKey>",
       description = "Comma separated Ethereum account private keys. ",
@@ -154,6 +161,7 @@ public class Options {
       if (genesisFile != null) {
         final Path genesisPath = Paths.get(genesisFile);
         final DocumentContext documentContext = JsonPath.parse(genesisPath.toUri().toURL());
+        chainId = documentContext.read("$.chainId");
         final Map<String, Map<String, String>> alloc = documentContext.read("$.alloc");
         accountPrivateKeys = new ArrayList<>();
         recipientAddresses = new ArrayList<>();
@@ -169,6 +177,7 @@ public class Options {
       Logger.error(e);
     }
     return ImmutableChainFillerConfiguration.builder()
+        .chaindId(chainId)
         .fillerMode(fillerMode)
         .addAllRpcEndpoints(rpcEndpoints)
         .addAllAccountPrivateKeys(

--- a/src/main/java/tech/pegasys/net/config/ChainFillerConfiguration.java
+++ b/src/main/java/tech/pegasys/net/config/ChainFillerConfiguration.java
@@ -8,6 +8,8 @@ import org.immutables.value.Value;
 public interface ChainFillerConfiguration {
   FillerMode fillerMode();
 
+  long chaindId();
+
   int numThreads();
 
   int repeatEveryNSeconds();

--- a/src/main/java/tech/pegasys/net/core/ChainFillerTask.java
+++ b/src/main/java/tech/pegasys/net/core/ChainFillerTask.java
@@ -91,7 +91,9 @@ public class ChainFillerTask implements Runnable {
       final LegacyTransaction legacyTransaction =
           chainFiller
               .legacyTransactionCreator()
-              .create(BigInteger.valueOf(nonce.getAndIncrement()), initialGasPrice);
+              .create(
+                  BigInteger.valueOf(nonce.getAndIncrement()),
+                  web3.ethGasPrice().send().getGasPrice());
       final byte[] signedMessage = TransactionSigner.sign(legacyTransaction, credentials);
       web3.ethSendRawTransaction(Numeric.toHexString(signedMessage)).send();
       chainFiller.reporter().incLegacyTransactions();

--- a/src/main/java/tech/pegasys/net/core/batch/BatchRpcFillerService.java
+++ b/src/main/java/tech/pegasys/net/core/batch/BatchRpcFillerService.java
@@ -66,7 +66,7 @@ public class BatchRpcFillerService {
     }
   }
 
-  private void generateTransaction() throws Exception{
+  private void generateTransaction() throws Exception {
     final ActionableAccount account = RandomUtils.pickRandom(accounts);
     final String transaction;
     switch (transactionTypeSelector.next()) {

--- a/src/main/java/tech/pegasys/net/core/tx/EIP1559TransactionCreatorService.java
+++ b/src/main/java/tech/pegasys/net/core/tx/EIP1559TransactionCreatorService.java
@@ -30,6 +30,7 @@ public class EIP1559TransactionCreatorService implements EIP1559TransactionCreat
   public EIP1559Transaction create(final TransactionPayload transactionPayload) {
     final Account recipient = accountRepository.random();
     return ImmutableEIP1559Transaction.builder()
+        .chainId(configuration.chaindId())
         .nonce(BigInteger.valueOf(transactionPayload.getNonce()))
         .recipientAddress(recipient.address())
         .value(new BigDecimal(transactionPayload.getValue()))
@@ -43,6 +44,7 @@ public class EIP1559TransactionCreatorService implements EIP1559TransactionCreat
       final BigInteger nonce, final BigInteger gasPremium, final BigInteger feeCap) {
     final Account recipient = accountRepository.random();
     return ImmutableEIP1559Transaction.builder()
+        .chainId(configuration.chaindId())
         .nonce(nonce)
         .recipientAddress(recipient.address())
         .value(


### PR DESCRIPTION
Sample of command to send eip1559 transactions
> ./chain-filler --rpc-endpoints=http://X.X.X.X:8545 --num-transactions=10 --num-contracts=0 --eip-1559-tx-weight=1 --num-threads=2 --fuzz-transfer-value-lower-bound-eth=0.01 --fuzz-transfer-value-upper-bound-eth=0.02 --filler-mode=scheduler --repeat-every-n-seconds=4 --tx-export-file=/dev/null --account-private-keys=0x..... --recipient-addresses=0x..... --chain-id=1642